### PR TITLE
Fix module path spelling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/liang-wj/go-mertric
+module github.com/liangweijiang/go-mertric
 
 go 1.23.2
 


### PR DESCRIPTION
Correct the spelling of the module path from `github.com/liang-wj/go-mertric` to `github.com/liangweijiang/go-mertric` to ensure it matches the correct repository.