### PR TITLE
Fix module name spelling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/liangweijiang/go-mertric
+module github.com/liangweijiang/go-metric
 
 go 1.23.2
 


### PR DESCRIPTION
Corrected the spelling of the module name from `go-mertric` to `go-metric` in the go.mod file. This change ensures the module name is accurate and consistent.