### PR TITLE
Move files from `pkg/sdk` to `meter`

### DIFF
--- a/meter/factory.go
+++ b/meter/factory.go
@@ -1,4 +1,4 @@
-package sdk
+package meter
 
 import (
 	"github.com/liangweijiang/go-metric/internal/meter/nop"

--- a/meter/factory_test.go
+++ b/meter/factory_test.go
@@ -1,4 +1,4 @@
-package sdk
+package meter
 
 import (
 	"github.com/liangweijiang/go-metric/pkg/interfaces"

--- a/meter/global.go
+++ b/meter/global.go
@@ -1,4 +1,4 @@
-package sdk
+package meter
 
 import (
 	"github.com/liangweijiang/go-metric/internal/global"

--- a/meter/option.go
+++ b/meter/option.go
@@ -1,4 +1,4 @@
-package sdk
+package meter
 
 import (
 	"github.com/liangweijiang/go-metric/pkg/config"


### PR DESCRIPTION
Moved factory, factory_test, global, and option files from the `pkg/sdk` directory to the `meter` directory and updated their package names accordingly.